### PR TITLE
Fix misc. source comment typos

### DIFF
--- a/freecad/XR/commonXR.py
+++ b/freecad/XR/commonXR.py
@@ -1603,7 +1603,7 @@ class XRwidget(QOpenGLWidget):
             docInter.recompute()
 
     # this function selects a FreeCAD model (document object)
-    # also opens a menu with avaiable actions
+    # also opens a menu with available actions
     def interact_select_mode(self):
         hand = self.secondary_con
         con = self.xr_con[hand]
@@ -1620,7 +1620,7 @@ class XRwidget(QOpenGLWidget):
                     conXR.AnInpEv.JUST_PRESSED):
                 docInter.clear_selection()
                 docInter.select_object(transform, self.view)
-                # point location have to be transformed from Base::Vector to SbVec3f
+                # point location has to be transformed from Base::Vector to SbVec3f
                 # then transformed from XR coordinates to doc coordinates
                 i_sec = docInter.get_sel_sbvec()
                 i_sec_xr = self.get_xr_sbvec(i_sec)

--- a/freecad/XR/previewCoin.py
+++ b/freecad/XR/previewCoin.py
@@ -41,10 +41,10 @@ class coinPreview:
         self.prev_sep.addChild(self.draw_prev_sep)
         self.prev_sep.addChild(self.working_plane_sep)
 
-        # one separator containts objects that can be picked (for snap)
+        # one separator contains objects that can be picked (for snap)
         # other one unpickable objects, only for visualisation
-        # we decide here to not snap to line we are drawing, just to
-        # points at the ends of the finished lines
+        # we decide here to not snap to line we are drawing, instead
+        # to points at the ends of the finished lines
         self.not_pick_sep = SoSeparator()
         unpickable = SoPickStyle()
         unpickable.style = SoPickStyle.UNPICKABLE
@@ -99,7 +99,7 @@ class coinPreview:
     def clean_preview(self):
         self.draw_prev_sep.whichChild = SO_SWITCH_NONE
         self.pline_vtxs.vertex.deleteValues(
-            2)  # do not delete 2 first vertices
+            2)  # do not delete first 2 vertices
         self.pnt_vtxs.vertex.deleteValues(1)
         self.point_counter = 0
 


### PR DESCRIPTION
Found via `codespell -S "./freecad/XR/XRWorkbench_rc.py"`

Also includes some grammar fixes.