### PR TITLE
 Update icon path in package.xml #1

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,7 @@
 
   <url type="documentation">https://github.com/kwahoo2/freecad-xr-workbench/tree/ec7591407cdca6d69271ac58bfa31e2c64a6b139/Resources/doc</url>
 
-  <icon>Gui/Resources/icons/preferences-virtual_reality.svg</icon>
+  <icon>Resources/Gui/Resources/icons/preferences-virtual_reality.svg</icon>
 
   <content>
     <workbench>


### PR DESCRIPTION
Update `<icon>` path in `package.xml` as a top-level tag as recommended by the [Addon Metadata guide on the wiki](https://wiki.freecad.org/Package_Metadata#Required_child_tags), using the correct path for [the icon file](https://github.com/kwahoo2/freecad-xr-workbench/blob/main/Resources/Gui/Resources/icons/preferences-virtual_reality.svg).